### PR TITLE
refactor: rebuild build-template.sh for layer-specific template generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,11 @@ node_modules
 
 # macOS
 .DS_Store
-# Generated combined template - do not edit directly
+
+# Generated templates (built from parts) - do not edit directly
 templates/template.regent
+templates/*-domain-template.regent
+templates/*-data-template.regent
+templates/*-infra-template.regent
+templates/*-presentation-template.regent
+templates/*-main-template.regent


### PR DESCRIPTION
## Summary
Refactored the build script to generate 15 layer-specific templates instead of 3 combined templates, providing more granular and focused code generation capabilities.

## What Changed
### 🔧 Build Script Refactor
- **New Output Format**: `[backend|frontend|fullstack]-[layer]-template.regent`
- **15 Templates Generated**: 3 targets (backend, frontend, fullstack) × 5 layers (domain, data, infra, presentation, main)
- **Proper Assembly Order**:
  1. Shared header (`00-header.part.regent`)
  2. Target structure (`01-structure.part.regent`)
  3. Target architecture (`02-architecture.part.regent`)
  4. Target rules (`03-rules.part.regent`)
  5. Layer implementation (`01-domain` through `05-main`)
  6. Shared validation (for presentation layer only)
  7. Shared footer (`01-footer.part.regent`)

### 📊 Template Statistics
Successfully generates:
- 5 Backend templates: domain, data, infra, presentation, main
- 5 Frontend templates: domain, data, infra, presentation, main
- 5 Fullstack templates: domain, data, infra, presentation, main

Each template ranges from ~2,000 to ~3,600 lines depending on the layer complexity.

### 🎨 Improved UX
- Beautiful colored output with Unicode box characters
- Real-time progress indicators
- Build summary with line counts
- YAML validation support when `yq` is installed
- Clear usage instructions

### 📝 Other Changes
- Updated `.gitignore` to exclude generated templates from version control
- Templates are now built on-demand and not committed to the repository

## Breaking Changes
⚠️ **Templates are now generated per layer instead of single combined files**
- Old: `backend-template.regent`, `frontend-template.regent`, `fullstack-template.regent`
- New: `[target]-[layer]-template.regent` (e.g., `backend-domain-template.regent`)

## Test Plan
- [x] Script executes without errors
- [x] All 15 templates are generated successfully
- [x] Each template contains correct parts in proper order
- [x] Validation layer only added to presentation templates
- [x] Footer included in all templates
- [x] Generated templates are properly gitignored

## Usage
```bash
# Build all templates
./templates/build-template.sh

# Use a specific template
npx tsx execute-template.ts templates/backend-domain-template.regent
```

🤖 Generated with [Claude Code](https://claude.ai/code)