### PR TITLE
fix: resolve post-reorganization TypeScript errors and verify build

### DIFF
--- a/core/rlhf-system.ts
+++ b/core/rlhf-system.ts
@@ -816,8 +816,10 @@ class EnhancedRLHFSystem {
   private setCachedResult(key: string, result: any): void {
     if (this.patternCache.size >= this.maxCacheSize) {
       const firstKey = this.patternCache.keys().next().value;
-      this.patternCache.delete(firstKey);
-      this.cacheStats.evictions++;
+      if (firstKey !== undefined) {
+        this.patternCache.delete(firstKey);
+        this.cacheStats.evictions++;
+      }
     }
 
     this.patternCache.set(key, {

--- a/scripts/rlhf-autofix.ts
+++ b/scripts/rlhf-autofix.ts
@@ -165,7 +165,7 @@ fi
           const conceptName = step.id
             .replace(/create-/, '')
             .replace(/-/g, ' ')
-            .replace(/\b\w/g, l => l.toUpperCase());
+            .replace(/\b\w/g, (l: string) => l.toUpperCase());
 
           step.template = `/**
  * @domainConcept ${conceptName}

--- a/scripts/rlhf-dashboard.ts
+++ b/scripts/rlhf-dashboard.ts
@@ -274,7 +274,7 @@ class RLHFDashboard {
     const topError = Object.entries(report.summary.commonErrors || {})
       .sort(([, a]: any, [, b]: any) => b - a)[0];
 
-    if (topError && topError[1] > 3) {
+    if (topError && Number(topError[1]) > 3) {
       recommendations.push({
         priority: 'medium',
         message: `"${topError[0]}" errors occurring frequently (${topError[1]} times).`,

--- a/validate-template.ts
+++ b/validate-template.ts
@@ -447,7 +447,7 @@ async function main() {
 }
 
 // Run if called directly
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch(console.error)
 }
 


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation errors that were present after PR #49's file reorganization.

## Issues Found and Fixed

### ✅ TypeScript Errors Resolved
1. **core/rlhf-system.ts:819** - Added undefined check for cache eviction
2. **scripts/rlhf-autofix.ts:168** - Added type annotation for replace callback
3. **scripts/rlhf-dashboard.ts:277** - Fixed type casting for error counting
4. **validate-template.ts:450** - Updated ES module check for ESM compatibility

### ✅ Verification Completed
- ✅ `npx tsc --noEmit` - TypeScript compilation passes
- ✅ `npm test` - All tests passing
- ✅ `npm run templates:validate-all` - Script works correctly
- ✅ `npm run rlhf:dashboard` - Dashboard script functional
- ✅ No broken imports found in moved files
- ✅ No references to old paths remain

## Testing
```bash
# TypeScript compilation
npx tsc --noEmit

# Run tests
npm test

# Verify scripts work
npm run templates:validate-all
npm run rlhf:dashboard -- --help
```

## Impact
- No functional changes, only TypeScript fixes
- All scripts now work correctly after reorganization
- Build and tests are green

Fixes issues identified in the post-merge review of PR #49.

🤖 Generated with [Claude Code](https://claude.ai/code)