### PR TITLE
feat: prepare package.json for NPM publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,47 @@
 {
-  "name": "spec-kit-clean-archicteture",
+  "name": "@thiagobutignon/spec-kit-clean-architecture",
   "version": "1.0.0",
+  "description": "CLI tool for spec-driven Clean Architecture development with AI-assisted code generation",
   "type": "module",
-  "main": "index.js",
+  "main": "src/cli/main.js",
   "bin": {
     "spec-ca": "./bin/spec-ca"
   },
-  "repository": "git@github.com:thiagobutignon/spec-kit-clean-archicteture.git",
+  "files": [
+    "bin/**/*",
+    "src/**/*",
+    "templates/**/*",
+    ".claude/**/*",
+    "*.md",
+    "package.json"
+  ],
+  "keywords": [
+    "clean-architecture",
+    "cli",
+    "ai-assisted",
+    "spec-driven",
+    "typescript",
+    "code-generation",
+    "tdd",
+    "ddd"
+  ],
+  "homepage": "https://github.com/thiagobutignon/spec-kit-clean-archicteture#readme",
+  "bugs": {
+    "url": "https://github.com/thiagobutignon/spec-kit-clean-archicteture/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thiagobutignon/spec-kit-clean-archicteture.git"
+  },
   "author": "Thiago Butignon <thiagobutignon@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
+    "prepare": "npm run templates:build",
+    "prepublishOnly": "npm run test",
+    "postinstall": "chmod +x bin/spec-ca",
     "lint": "eslint .",
     "test": "vitest --passWithNoTests",
     "templates:validate": "tsx validate-template.ts",


### PR DESCRIPTION
## 📦 NPM Publication Preparation

This PR prepares the package.json for global NPM publication, enabling users to install and use the `spec-ca` CLI from anywhere.

### 🎯 Changes Made

#### Package Configuration
- **Scoped Package**: Changed to `@thiagobutignon/spec-kit-clean-architecture`
- **Description**: Added comprehensive description for NPM registry
- **Keywords**: Added relevant keywords for discoverability
- **Files Array**: Specified which files to include in NPM package

#### CLI Installation
- **Global Installation**: Configured for `npm install -g @thiagobutignon/spec-kit-clean-architecture`
- **Binary Command**: `spec-ca` will be available globally after installation
- **Node.js Requirement**: Minimum Node.js >=18.0.0

#### Build Scripts
- **prepare**: Automatically builds templates on install
- **prepublishOnly**: Runs tests before publication
- **postinstall**: Ensures CLI binary has execute permissions

### 🚀 After Merge

Users will be able to:
```bash
# Install globally
npm install -g @thiagobutignon/spec-kit-clean-architecture

# Use from anywhere
spec-ca init my-project --ai claude
spec-ca check
```

### 📋 Publication Checklist

- [x] Package.json configured for NPM
- [x] Scoped package name set
- [x] Files array configured
- [x] Build scripts added
- [ ] NPM account verified
- [ ] Publish to NPM registry

### 🔧 Testing

After merge, test local installation:
```bash
npm pack
npm install -g ./package-name.tgz
spec-ca --help
```

🎯 **Ready for immediate merge and NPM publication!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)