### PR TITLE
fix: add missing configuration files to init command (v1.0.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-kit-clean-architecture",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "CLI tool for spec-driven Clean Architecture development with AI-assisted code generation",
   "type": "module",
   "main": "src/cli/main.js",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -18,12 +18,13 @@ interface InitOptions {
   debug?: boolean;
 }
 
-const AI_CHOICES = {
-  'claude': 'Claude Code',
-  'gemini': 'Gemini CLI',
-  'copilot': 'GitHub Copilot',
-  'cursor': 'Cursor'
-};
+// AI assistant options for future use
+// const AI_CHOICES = {
+//   'claude': 'Claude Code',
+//   'gemini': 'Gemini CLI',
+//   'copilot': 'GitHub Copilot',
+//   'cursor': 'Cursor'
+// };
 
 export async function initCommand(projectName: string | undefined, options: InitOptions): Promise<void> {
   console.log(chalk.cyan('🏗️ Initializing Spec-Kit Clean Architecture project...\n'));
@@ -55,6 +56,7 @@ export async function initCommand(projectName: string | undefined, options: Init
     await createProjectStructure(projectPath, options);
 
     // Initialize git if requested
+    // Initialize git by default unless explicitly disabled
     if (options.git !== false) {
       await initializeGit(projectPath);
     }
@@ -151,11 +153,33 @@ async function createProjectStructure(projectPath: string, options: InitOptions)
     console.log(chalk.yellow('⚠️  Warning: VS Code configuration not found in package'));
   }
 
+  // Copy root TypeScript files
+  const rootTsFiles = [
+    'execute-steps.ts',
+    'validate-template.ts',
+    'tsconfig.json',
+    'vitest.config.ts',
+    'eslint.config.js',
+    'regent.schema.json'
+  ];
+
+  console.log(chalk.cyan('📝 Copying configuration and utility files...'));
+  for (const file of rootTsFiles) {
+    const sourcePath = path.join(packageRoot, file);
+    const targetPath = path.join(projectPath, file);
+
+    if (await fs.pathExists(sourcePath)) {
+      await fs.copy(sourcePath, targetPath);
+    } else {
+      console.log(chalk.yellow(`⚠️  Warning: ${file} not found in package`));
+    }
+  }
+
   // Create initial files
   await createInitialFiles(projectPath, options);
 }
 
-async function createInitialFiles(projectPath: string, options: InitOptions): Promise<void> {
+async function createInitialFiles(projectPath: string, _options: InitOptions): Promise<void> {
   const packageJson = {
     name: path.basename(projectPath),
     version: '1.0.0',


### PR DESCRIPTION
## Summary
- Add missing configuration and utility files to the init command
- Fix TypeScript compilation errors
- Prepare version 1.0.3 for NPM release

## Changes
- ✅ Add `execute-steps.ts` and `validate-template.ts` to copied files
- ✅ Add TypeScript configuration files (`tsconfig.json`, `vitest.config.ts`)
- ✅ Add ESLint configuration (`eslint.config.js`)
- ✅ Add Regent schema for template validation (`regent.schema.json`)
- ✅ Fix TypeScript errors (unused variables, type issues)
- ✅ Bump version to 1.0.3

## Test Plan
- [ ] Test local installation with `npm pack`
- [ ] Verify all files are copied correctly
- [ ] Test with `spec-ca init test-project`
- [ ] Verify TypeScript compilation passes

## Impact
This ensures users get a complete project setup with all necessary configuration files when using `spec-ca init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)