### PR TITLE
fix: update .claude documentation paths for v1.0.4 structure (v1.0.5)

### DIFF
--- a/.claude/agents/backend-specialist.md
+++ b/.claude/agents/backend-specialist.md
@@ -259,17 +259,17 @@ You generate production-ready backend code that scales, performs, and maintains 
 
 This agent leverages core system tools:
 
-### execute-steps.ts
+### .regent/config/execute-steps.ts
 - Executes YAML implementation plans
 - Creates backend files and structures
 - Validates code quality with RLHF scoring
 
-### validate-template.ts
+### .regent/config/validate-template.ts
 - Validates backend templates
 - Ensures Clean Architecture compliance
 - Checks for layer violations
 
-### templates/backend_*.yaml
+### .regent/templates/backend_*.yaml
 - Pre-validated backend templates
 - Domain, data, infrastructure patterns
 - Repository and use case implementations

--- a/.claude/agents/clean-architecture-generator.md
+++ b/.claude/agents/clean-architecture-generator.md
@@ -149,17 +149,17 @@ You use these commands in sequence:
 
 This agent integrates with core system tools:
 
-### execute-steps.ts
+### .regent/config/execute-steps.ts
 - Main execution engine for YAML implementation plans
 - Handles file creation, refactoring, and validation
 - Provides RLHF scoring and feedback
-- Located at: `/execute-steps.ts`
+- Located at: `/.regent/config/execute-steps.ts`
 
-### validate-template.ts
+### .regent/config/validate-template.ts
 - Validates YAML plans against JSON schemas
 - Ensures template compliance
 - Checks for architectural violations
-- Located at: `/validate-template.ts`
+- Located at: `/.regent/config/validate-template.ts`
 
 ### core/rlhf-system.ts
 - Enhanced RLHF scoring system

--- a/.claude/agents/frontend-specialist.md
+++ b/.claude/agents/frontend-specialist.md
@@ -298,17 +298,17 @@ You generate production-ready frontend code that provides excellent user experie
 
 This agent leverages core system tools:
 
-### execute-steps.ts
+### .regent/config/execute-steps.ts
 - Executes YAML implementation plans
 - Creates frontend components and structures
 - Validates code quality with RLHF scoring
 
-### validate-template.ts
+### .regent/config/validate-template.ts
 - Validates frontend templates
 - Ensures Clean Architecture compliance
 - Checks for UI/component best practices
 
-### templates/frontend_*.yaml
+### .regent/templates/frontend_*.yaml
 - Pre-validated frontend templates
 - Component, hook, and service patterns
 - State management implementations

--- a/.claude/agents/fullstack-architect.md
+++ b/.claude/agents/fullstack-architect.md
@@ -326,17 +326,17 @@ You create cohesive fullstack solutions where frontend and backend work in perfe
 
 This agent leverages core system tools:
 
-### execute-steps.ts
+### .regent/config/execute-steps.ts
 - Orchestrates fullstack implementations
 - Creates both frontend and backend structures
 - Ensures API contract consistency
 
-### validate-template.ts
+### .regent/config/validate-template.ts
 - Validates fullstack templates
 - Checks cross-layer compatibility
 - Ensures type safety across stack
 
-### templates/fullstack_*.yaml
+### .regent/templates/fullstack_*.yaml
 - Shared type definitions
 - API contract templates
 - End-to-end feature patterns

--- a/.claude/agents/layer-validator.md
+++ b/.claude/agents/layer-validator.md
@@ -185,11 +185,11 @@ You never compromise on architectural integrity and always provide clear, action
 
 This agent integrates with core validation tools:
 
-### validate-template.ts
+### .regent/config/validate-template.ts
 - Primary validation engine
 - JSON schema validation
 - Template compliance checking
-- Located at: `/validate-template.ts`
+- Located at: `/.regent/config/validate-template.ts`
 
 ### core/rlhf-system.ts
 - Architectural scoring system
@@ -197,11 +197,11 @@ This agent integrates with core validation tools:
 - Layer-aware validation rules
 - Located at: `/core/rlhf-system.ts`
 
-### execute-steps.ts
+### .regent/config/execute-steps.ts
 - Runtime validation during execution
 - Step-by-step verification
 - Error detection and reporting
-- Located at: `/execute-steps.ts`
+- Located at: `/.regent/config/execute-steps.ts`
 
 These tools work together to ensure strict Clean Architecture compliance.
 

--- a/.claude/commands/03-generate-layer-code.md
+++ b/.claude/commands/03-generate-layer-code.md
@@ -51,7 +51,7 @@ scoring:
   catastrophic:
     score: -2
     causes: ["Architecture violations", "Wrong REPLACE/WITH format"]
-source_template: "templates/[LAYER]_TEMPLATE.yaml"
+source_template: ".regent/templates/[LAYER]_TEMPLATE.yaml"
 validation_script: "npx tsx validate-implementation.ts"
 previous_command: "/02-validate-layer-plan from json: <json>"
 next_command: "/04-reflect-layer-lessons from yaml: <generated-yaml>"
@@ -126,7 +126,7 @@ spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| **Template** | `templates/[LAYER]_TEMPLATE.yaml` | Master template |
+| **Template** | `.regent/templates/[LAYER]_TEMPLATE.yaml` | Master template |
 | **Directives** | `# AI-NOTE:` comments | Must follow all |
 | **Placeholders** | `__PLACEHOLDER__` variables | Must replace all |
 | **Validation** | `validate-implementation.ts` | Must pass validation |
@@ -159,7 +159,7 @@ spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
 <details>
 <summary>Expand for Create Mode Steps</summary>
 
-1. **Initialize**: Copy `templates/[LAYER]_TEMPLATE.yaml` verbatim
+1. **Initialize**: Copy `.regent/templates/[LAYER]_TEMPLATE.yaml` verbatim
 2. **Generate Steps**:
    - Keep `create-feature-branch` as FIRST step
    - Keep `create-structure` as SECOND step
@@ -236,7 +236,7 @@ spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
 ### Mandatory Validation Steps:
 
 ```bash
-npx tsx validate-implementation.ts templates/[LAYER]_TEMPLATE.yaml <generated-yaml-path>
+npx tsx .regent/config/validate-template.ts .regent/templates/[LAYER]_TEMPLATE.yaml <generated-yaml-path>
 ```
 
 ### Self-Correction Loop:
@@ -324,7 +324,7 @@ After you generate the YAML:
 graph LR
     A[AI Generates YAML] --> B[User Reviews]
     B --> C{Correct?}
-    C -->|Yes| D[User Runs execute-steps.ts]
+    C -->|Yes| D[User Runs .regent/config/execute-steps.ts]
     C -->|No| E[User Requests Changes]
     E --> A
     style D fill:#90EE90

--- a/.claude/commands/06-execute-layer-steps.md
+++ b/.claude/commands/06-execute-layer-steps.md
@@ -46,7 +46,7 @@ rlhf_scoring:
     score: 2
     emoji: "🏆"
     causes: ["Clean Architecture + DDD + ubiquitous language"]
-execution_script: "npx tsx execute-steps.ts"
+execution_script: "npx tsx .regent/config/execute-steps.ts"
 previous_command: "/05-evaluate-layer-results from yaml: <yaml>"
 next_command_success: "/08-apply-layer-improvements"
 next_command_failure: "/07-fix-layer-errors from yaml: <yaml-with-failed-step>"
@@ -56,7 +56,7 @@ next_command_failure: "/07-fix-layer-errors from yaml: <yaml-with-failed-step>"
 
 ## 🤖 RLHF Scoring During Execution
 
-The execute-steps.ts script automatically calculates RLHF scores for each step:
+The .regent/config/execute-steps.ts script automatically calculates RLHF scores for each step:
 
 | Score | Level | Emoji | Meaning |
 |-------|-------|-------|---------|
@@ -126,7 +126,7 @@ spec/001-user-registration/[LAYER]/src/features/user-registration/[LAYER]/usecas
 
 ```mermaid
 graph TD
-    A[Initialize Execution] --> B[Load execute-steps.ts]
+    A[Initialize Execution] --> B[Load .regent/config/execute-steps.ts]
     B --> C[Run Script with YAML]
     C --> D[Stream Output]
     D --> E{Monitor Exit Code}
@@ -141,10 +141,10 @@ graph TD
 ### Execution Steps:
 
 1. **Initialize**: Announce start of execution
-2. **Load Script**: Load `execute-steps.ts` from toolchain
+2. **Load Script**: Load `.regent/config/execute-steps.ts` from toolchain
 3. **Execute Script**:
    ```bash
-   npx tsx execute-steps.ts {{path_to_input_yaml}}
+   npx tsx .regent/config/execute-steps.ts {{path_to_input_yaml}}
    ```
 4. **Stream Output**: Real-time stdout/stderr with RLHF scores
 5. **Monitor Exit Code**: Wait for completion
@@ -231,7 +231,7 @@ Aborting execution. The YAML file has been updated with the failure details.
 
 ## 8. Script Capabilities
 
-The `execute-steps.ts` script provides:
+The `.regent/config/execute-steps.ts` script provides:
 
 | Feature | Description |
 |---------|-------------|

--- a/.claude/commands/08-apply-layer-improvements.md
+++ b/.claude/commands/08-apply-layer-improvements.md
@@ -23,8 +23,8 @@ parameters:
     format: '{"improvements_applied": [], "metrics": {}, "next_steps": []}'
   templates_updated:
     type: "file"
-    location: "templates/DOMAIN_TEMPLATE.yaml"
-    backup: "templates/.backup/DOMAIN_TEMPLATE.yaml.bak"
+    location: ".regent/templates/DOMAIN_TEMPLATE.yaml"
+    backup: ".regent/templates/.backup/DOMAIN_TEMPLATE.yaml.bak"
 rlhf_score_patterns:
   catastrophic:
     score: -2
@@ -390,8 +390,8 @@ Return to the beginning of the pipeline:
 ### 2. Review Improvements
 Check updated templates and patterns:
 ```bash
-cat templates/DOMAIN_TEMPLATE.yaml
-diff templates/.backup/DOMAIN_TEMPLATE.yaml.bak templates/DOMAIN_TEMPLATE.yaml
+cat .regent/templates/DOMAIN_TEMPLATE.yaml
+diff .regent/templates/.backup/DOMAIN_TEMPLATE.yaml.bak .regent/templates/DOMAIN_TEMPLATE.yaml
 ```
 
 ### 3. Generate Reports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-kit-clean-architecture",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "CLI tool for spec-driven Clean Architecture development with AI-assisted code generation",
   "type": "module",
   "main": "src/cli/main.js",


### PR DESCRIPTION
## Summary
Updates all paths in .claude documentation to match the new v1.0.4 structure where all spec-kit files are in `.regent/` directory.

## Changes
- ✅ Update templates paths from `templates/` to `.regent/templates/`
- ✅ Update `execute-steps.ts` path to `.regent/config/execute-steps.ts`
- ✅ Update `validate-template.ts` path to `.regent/config/validate-template.ts`
- ✅ Fix all references in commands documentation
- ✅ Fix all references in agents documentation

## Files Updated
- `.claude/commands/03-generate-layer-code.md`
- `.claude/commands/06-execute-layer-steps.md`
- `.claude/commands/08-apply-layer-improvements.md`
- `.claude/agents/backend-specialist.md`
- `.claude/agents/frontend-specialist.md`
- `.claude/agents/fullstack-architect.md`

## Impact
This ensures that all Claude commands and agents use the correct paths after the v1.0.4 structural changes.

## Testing
- [ ] Commands reference correct paths
- [ ] Agents reference correct paths
- [ ] No broken references

🤖 Generated with [Claude Code](https://claude.com/claude-code)