### PR TITLE
Fix: Corrigir paths hardcoded nos comandos slash

### DIFF
--- a/.claude/commands/01-plan-layer-features.md
+++ b/.claude/commands/01-plan-layer-features.md
@@ -25,8 +25,8 @@ parameters:
     required: true
   output_location:
     type: "path"
-    pattern: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/plan.json"
-    example: "spec/001-user-registration/[LAYER]/plan.json"
+    pattern: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/plan.json"
+    example: "./spec/001-user-registration/[LAYER]/plan.json"
 scoring:
   levels:
     catastrophic: -2
@@ -140,8 +140,8 @@ Each layer has specific requirements for perfect score - see `scoring.perfect_re
 Your **only** output for this task is a single, complete, and well-formed **JSON object**. This JSON will serve as the input for the `/03-generate-layer-code` command.
 
 **OUTPUT LOCATION**:
-- Save at: `spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/plan.json`
-- Example: `spec/001-user-registration/[LAYER]/plan.json`
+- Save at: `./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/plan.json`
+- Example: `./spec/001-user-registration/[LAYER]/plan.json`
 - Feature numbers should be sequential (001, 002, 003, etc.)
 
 ## 2. Layer Selection

--- a/.claude/commands/03-generate-layer-code.md
+++ b/.claude/commands/03-generate-layer-code.md
@@ -23,8 +23,8 @@ parameters:
     required: false
   output:
     type: "yaml"
-    location: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
-    example: "spec/001-user-registration/[LAYER]/implementation.yaml"
+    location: "././spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
+    example: "./spec/001-user-registration/[LAYER]/implementation.yaml"
 modes:
   create:
     description: "Generate new YAML from JSON plan"
@@ -103,7 +103,7 @@ Your **only** output is a complete and valid YAML file content.
 
 **Output Location:**
 ```
-spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
+./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
 ```
 
 **Naming Convention:**
@@ -111,7 +111,7 @@ spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml
 |-----------|--------|---------|
 | FEATURE_NUMBER | Sequential 3-digit | 001, 002, 003 |
 | FEATURE_NAME | kebab-case | user-registration |
-| Full Path | Combined | spec/001-user-registration/[LAYER]/implementation.yaml |
+| Full Path | Combined | ./spec/001-user-registration/[LAYER]/implementation.yaml |
 
 ## 2. Prohibited Actions ❌
 

--- a/.claude/commands/04-reflect-layer-lessons.md
+++ b/.claude/commands/04-reflect-layer-lessons.md
@@ -14,7 +14,7 @@ parameters:
   input:
     type: "yaml"
     description: "Complete validated YAML from /03-generate-layer-code"
-    location: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
+    location: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
     required: true
   output_success:
     type: "json"
@@ -94,7 +94,7 @@ Act as a **senior software architect** reviewing a detailed implementation plan.
 
 | Parameter | Type | Location | Purpose |
 |-----------|------|----------|---------|
-| **YAML Plan** | YAML | `spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml` | Complete validated plan from /03-generate-layer-code |
+| **YAML Plan** | YAML | `./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml` | Complete validated plan from /03-generate-layer-code |
 
 ## 4. Reflection Checklist (Guiding Questions)
 

--- a/.claude/commands/05-evaluate-layer-results.md
+++ b/.claude/commands/05-evaluate-layer-results.md
@@ -14,7 +14,7 @@ parameters:
   input:
     type: "yaml"
     description: "Complete YAML plan from /04-reflect-layer-lessons"
-    location: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
+    location: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
     required: true
   output_approved:
     type: "json"
@@ -105,7 +105,7 @@ Act as a **Principal Engineer** performing a final architectural review on an im
 
 | Parameter | Type | Location | Description |
 |-----------|------|----------|-------------|
-| **YAML Plan** | YAML | `spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml` | Complete, potentially revised YAML from /04-reflect-layer-lessons |
+| **YAML Plan** | YAML | `./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml` | Complete, potentially revised YAML from /04-reflect-layer-lessons |
 
 ## 4. Evaluation Principles (The Constitution)
 

--- a/.claude/commands/06-execute-layer-steps.md
+++ b/.claude/commands/06-execute-layer-steps.md
@@ -17,8 +17,8 @@ parameters:
     required: true
   working_directory:
     type: "path"
-    pattern: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/"
-    example: "spec/001-user-registration/[LAYER]/"
+    pattern: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/"
+    example: "./spec/001-user-registration/[LAYER]/"
   output_success:
     type: "json"
     format: '{"status": "SUCCESS", "message": "string", "commit_hashes": ["string"], "final_rlhf_score": number}'
@@ -100,7 +100,7 @@ Act as an **automated build engineer**. Execute the approved YAML implementation
 | Parameter | Description | Example |
 |-----------|-------------|---------|
 | **YAML Plan** | Complete approved YAML from /05-evaluate-layer-results | Full YAML content |
-| **Working Directory** | Base path for all file operations | `spec/001-user-registration/[LAYER]/` |
+| **Working Directory** | Base path for all file operations | `./spec/001-user-registration/[LAYER]/` |
 
 ### ⚠️ Important Path Resolution:
 When the plan specifies:
@@ -110,7 +110,7 @@ path: "src/features/user-registration/[LAYER]/usecases/register-user.ts"
 
 Actually create at:
 ```
-spec/001-user-registration/[LAYER]/src/features/user-registration/[LAYER]/usecases/register-user.ts
+./spec/001-user-registration/[LAYER]/src/features/user-registration/[LAYER]/usecases/register-user.ts
 ```
 
 ## 4. Prohibited Actions ❌
@@ -160,7 +160,7 @@ graph TD
 <summary>Success Output with RLHF Scoring</summary>
 
 ```
-🚀 Loading implementation file: spec/001-user-registration/[LAYER]/implementation.yaml
+🚀 Loading implementation file: ./spec/001-user-registration/[LAYER]/implementation.yaml
 🚀 Starting execution of 2 steps...
 
 ▶️  Processing Step 1/2: create-structure
@@ -193,7 +193,7 @@ graph TD
 <summary>Failure Output with RLHF -2</summary>
 
 ```
-🚀 Loading implementation file: spec/001-user-registration/[LAYER]/implementation.yaml
+🚀 Loading implementation file: ./spec/001-user-registration/[LAYER]/implementation.yaml
 🚀 Starting execution of 2 steps...
 
 ▶️  Processing Step 1/2: create-structure

--- a/.claude/commands/07-fix-layer-errors.md
+++ b/.claude/commands/07-fix-layer-errors.md
@@ -17,12 +17,12 @@ parameters:
     required: true
   working_directory:
     type: "path"
-    pattern: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/"
+    pattern: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/"
     description: "Base path for all file operations"
   output:
     type: "yaml"
     description: "Updated YAML with fix step appended"
-    location: "spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
+    location: "./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/implementation.yaml"
 rlhf_score_recovery:
   from_catastrophic:
     current: -2
@@ -76,7 +76,7 @@ Analyze a failed step in a YAML implementation plan and generate a **new correct
 | Input | Description |
 |-------|-------------|
 | **YAML with Failures** | Contains steps with `status: 'FAILED'` |
-| **Working Directory** | `spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/` |
+| **Working Directory** | `./spec/[FEATURE_NUMBER]-[FEATURE_NAME]/[LAYER]/` |
 | **Fix Strategy** | Append new fix step, preserve failed step |
 
 ## 3. Step-by-Step Execution Plan


### PR DESCRIPTION
## Summary
- Corrige bug crítico nos comandos slash onde paths estavam hardcoded
- Mudança de `spec/` para `./spec/` para usar diretório atual correto
- Descoberto durante tentativa de dogfooding

## Bug Encontrado
Durante o dogfooding (teste do sistema usando ele mesmo), descobrimos que:
- ❌ Comandos executados em `packages/cli/` criavam arquivos em `spec/` da raiz do projeto
- ❌ Paths hardcoded como `spec/[FEATURE]/[LAYER]/plan.json` 
- ✅ Corrigido para `./spec/[FEATURE]/[LAYER]/plan.json`

## Comandos Corrigidos
- `/01-plan-layer-features` - patterns e examples
- `/03-generate-layer-code` - output locations  
- `/04-reflect-layer-lessons` - file locations
- `/05-evaluate-layer-results` - YAML locations
- `/06-execute-layer-steps` - working directories
- `/07-fix-layer-errors` - patterns e locations

## Test plan
- [x] Identificar todas as referências hardcoded
- [x] Corrigir systematicamente com sed/regex
- [x] Validar que zero referências hardcoded restam
- [ ] Testar dogfooding após merge para validar correção

## Importância
Este bug impedia o dogfooding funcional - processo essencial para validar que o sistema realmente funciona usando seus próprios templates para gerar código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)