### PR TITLE
fix: replace generic __LAYER__ placeholders - Issue #69

### DIFF
--- a/.claude/commands/01-plan-layer-features.md
+++ b/.claude/commands/01-plan-layer-features.md
@@ -360,7 +360,7 @@ Your final JSON must follow this structure:
       "id": "step-identifier",
       "type": "[create_file|refactor_file]",
       "description": "Step description",
-      "path": "src/features/__FEATURE_NAME__/__USE_CASE_NAME__/__LAYER__/path/to/file.ts",
+      "path": "src/features/__FEATURE_NAME__/__USE_CASE_NAME__/domain/path/to/file.ts",
       "template": "// Code template with placeholders",
       "references": []
     }
@@ -385,7 +385,7 @@ Your final JSON must follow this structure:
     {
       "id": "create-register-user-use-case",
       "type": "create_file",
-      "path": "src/features/__FEATURE_NAME__/__USE_CASE_NAME__/__LAYER__/use-cases/register-user.ts",
+      "path": "src/features/__FEATURE_NAME__/__USE_CASE_NAME__/domain/use-cases/register-user.ts",
       "template": "export interface RegisterUser {\n  execute(input: RegisterUserInput): Promise<RegisterUserOutput>;\n}"
     }
   ]


### PR DESCRIPTION
## Summary
Replace generic `__LAYER__` placeholders with specific layer names in examples.

## Problem
Lines 363 and 388 use generic `__LAYER__` placeholder while other examples use specific layer names like 
'domain', 'data', 'infra'.

## Solution
- Line 363: `__LAYER__` → `domain`
- Line 388: `__LAYER__` → `domain`

## Consistency Check
Other examples already use specific names:
- Line 404: uses 'data' (correct)
- Configuration placeholders remain unchanged (correct)

Fixes #69