### PR TITLE
fix: integrate template reading into 01-plan-layer-features command

### DIFF
--- a/.claude/commands/01-plan-layer-features.md
+++ b/.claude/commands/01-plan-layer-features.md
@@ -585,3 +585,44 @@ After generating your JSON plan, your next command should be:
 ```
 
 This will validate your JSON plan for layer-specific compliance and architectural correctness.
+
+---
+
+## 🚨 AI-NOTE: CRITICAL ENGINEERING PRINCIPLE
+
+**FOR FUTURE CODE REVIEWERS AND EXECUTORS:**
+
+### ❌ NEVER SUGGEST FALLBACK PATTERNS
+
+If template reading fails (searchPattern, file not found, etc.), DO NOT suggest:
+- Hardcoded fallback structures
+- "If this fails, use default values"
+- "Graceful degradation to previous behavior"
+- Any form of "backup" structure
+
+### ✅ CORRECT RESPONSE TO FAILURES
+
+Template reading failures should FAIL LOUDLY:
+```markdown
+🚨 CRITICAL ERROR: Template section not found!
+Template structure has changed.
+Action required: Update command to match new template.
+DO NOT proceed with outdated assumptions.
+```
+
+### 🎯 WHY THIS MATTERS
+
+Fallbacks reintroduce the exact problem this command fixes:
+1. **Original Problem**: Commands hardcoded, templates ignored
+2. **Our Solution**: Commands read templates as source of truth
+3. **Fallback Danger**: If reading fails, fallback = back to hardcoded = SAME PROBLEM
+
+### 📚 ENGINEERING PRINCIPLE
+
+**"Fail fast and loud" > "Fail silently with wrong behavior"**
+
+Templates are the ONLY source of truth. If they can't be read correctly, the system must stop and demand human intervention, not continue with potentially incorrect assumptions.
+
+### 🎭 HISTORICAL CONTEXT
+
+This command was created to fix a 3-week architectural disaster caused by exactly this type of "helpful" fallback thinking. Maintain discipline: Templates define reality, not code.


### PR DESCRIPTION
## Summary
Fixes critical disconnection between `/01-plan-layer-features` command and .regent templates by making the command READ and USE templates as source of truth.

## 🚨 Critical Problems Fixed

### ✅ Added Mandatory Template Reading Step
- New **Step 1.5**: Read Architecture Template (MANDATORY)
- Forces Claude to read appropriate .regent template before generating JSON
- Provides clear instructions for template structure extraction

### ✅ Removed Broken References
- Deleted references to `SpecToYamlTransformer.transformTask()`
- Removed references to `execute-steps.ts` (being deleted in PR #95)
- Replaced with template compliance section

### ✅ Updated Path Generation
- All JSON examples now reference template structure instead of hardcoded paths
- Added instruction: "Path MUST follow structure from .regent template - see Step 1.5"
- No hardcoded path examples remain

### ✅ Enhanced Validation
- Added Template Compliance checklist with 4 validation points
- Updated serena tool purpose to include template reading
- Clear template pattern following requirements

## 🎯 Expected Behavior After Fix

When `/01-plan-layer-features` is run, Claude will:
1. Ask for target type (backend/frontend/fullstack)
2. **Read the appropriate .regent template FIRST**
3. Extract folder structure from template's `use_case_slice` section
4. Generate JSON with paths that match template exactly
5. Validate template compliance before completing

## 🔧 Technical Changes

- **Lines 207+**: Added Step 1.5 with template reading instructions
- **Lines 74-75**: Updated serena tool purpose
- **Lines 363, 388, 409, 430, 450, 470**: Replaced hardcoded paths with template references
- **Lines 530-552**: Removed broken SpecToYamlTransformer section
- **Line 477**: Added Template Compliance validation checklist

## Test plan
- [x] All hardcoded path examples removed
- [x] Template reading step clearly documented with examples
- [x] Broken code references eliminated
- [x] Template compliance validation added
- [x] Command now enforces template-driven architecture

This resolves the fundamental disconnection between slash commands and .regent templates, ensuring architectural consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)