### PR TITLE
fix: remove SpecToYamlTransformer references from /03-generate-layer-code command

### DIFF
--- a/.claude/commands/03-generate-layer-code.md
+++ b/.claude/commands/03-generate-layer-code.md
@@ -59,24 +59,6 @@ previous_command: "/02-validate-layer-plan from json: <json>"
 next_command: "/04-reflect-layer-lessons from yaml: <generated-yaml>"
 ---
 
-## 🔄 Integration with SpecToYamlTransformer
-
-When generating YAML for tasks, use the following approach:
-
-```typescript
-import { SpecToYamlTransformer } from '../../packages/cli/src/core/SpecToYamlTransformer.js';
-
-// For each task in the JSON plan:
-const transformer = new SpecToYamlTransformer();
-const workflow = await transformer.transformTask(taskId, taskListPath);
-await transformer.saveWorkflowAsYaml(workflow, `.regent/templates/${taskId}.yaml`);
-```
-
-This ensures:
-- GitFlow steps (branch, commit, PR) are included
-- Proper validation scripts are generated
-- YAML is compatible with execute-steps.ts
-
 # Task: Generate Selected Layer Code
 
 ## 🤖 RLHF Scoring System
@@ -445,7 +427,7 @@ After you generate the YAML:
 graph LR
     A[AI Generates YAML] --> B[User Reviews]
     B --> C{Correct?}
-    C -->|Yes| D[User Runs .regent/config/execute-steps.ts]
+    C -->|Yes| D[User Proceeds to /04-reflect-layer-lessons]
     C -->|No| E[User Requests Changes]
     E --> A
     style D fill:#90EE90


### PR DESCRIPTION
## 🐛 Bug Fix - Issue #100

### Problem
The `/03-generate-layer-code` command contained references to `SpecToYamlTransformer` and related components that were deleted in PR #95 (dead code removal). This caused catastrophic failure when users tried to execute the command after successful validation.

### Root Cause
**Dead Code Removal in PR #95:**
- ✅ Removed `packages/cli/` directory (8K+ lines)
- ✅ Removed `SpecToYamlTransformer` class
- ✅ Removed `execute-steps.ts`
- ❌ **MISSED**: Update `/03-generate-layer-code` command references

### Solution Applied
Following the same pattern as PR #96, this PR removes broken references:

1. **Removed Integration Section** (lines 62-78)
   - Removed `SpecToYamlTransformer` import example
   - Removed broken code references
   
2. **Updated User Workflow Diagram**
   - Changed from: `User Runs .regent/config/execute-steps.ts`
   - Changed to: `User Proceeds to /04-reflect-layer-lessons`

3. **Maintained Template-Driven Approach**
   - The file already has comprehensive template-driven documentation
   - No additional changes needed - only broken references removed

### Changes Made
- Removed Integration with SpecToYamlTransformer section
- Updated workflow diagram to reference next command
- Removed execute-steps.ts reference

### Impact
- ✅ **Workflow Unblocked**: Users can now progress through the entire Clean Architecture workflow
- ✅ **No Breaking Changes**: Template-driven approach remains intact
- ✅ **Consistent with PR #96**: Same fix pattern applied

### Testing
- [x] Verified no remaining references to `SpecToYamlTransformer`
- [x] Verified no remaining references to `execute-steps.ts`
- [x] Verified no remaining references to `packages/cli`
- [x] Verified template-driven approach is documented
- [x] Verified workflow diagram is updated

### Related
- Fixes #100
- Related to PR #95 (dead code removal)
- Related to PR #96 (same fix pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)