### PR TITLE
🐛 fix: treat 'already exists' MCP servers as skipped instead of failed (fixes #108)

### DIFF
--- a/src/cli/utils/mcp-installer.ts
+++ b/src/cli/utils/mcp-installer.ts
@@ -20,6 +20,9 @@ export const VERIFICATION_TIMEOUT = {
 // Retry configuration
 export const RETRY_DELAY_MS = 1000; // 1 second delay between retry attempts
 
+// Error message patterns
+const ALREADY_EXISTS_PATTERN = 'already exists';
+
 /**
  * Custom error class for MCP installation failures
  * Preserves original error as cause for debugging
@@ -66,11 +69,19 @@ export class MCPInstaller {
   }
 
   /**
+   * Type guard to check if error is MCPAlreadyExistsError
+   * Provides type-safe error checking
+   */
+  private isAlreadyExistsError(error: unknown): error is MCPAlreadyExistsError {
+    return error instanceof MCPAlreadyExistsError;
+  }
+
+  /**
    * Handle installation errors and update report accordingly
    * Reduces code duplication across all install methods
    */
   private handleInstallError(error: Error, serverName: string, displayName: string, report: InstallReport): void {
-    if (error instanceof MCPAlreadyExistsError) {
+    if (this.isAlreadyExistsError(error)) {
       report.skipped.push(`${serverName} (already installed)`);
       console.log(chalk.yellow(`⏭️  ${displayName} - Already installed (skipped)\n`));
     } else {
@@ -161,7 +172,7 @@ export class MCPInstaller {
       const stderr = error.stderr?.toString() || error.message || '';
 
       // Check if it's "already exists" error
-      if (stderr.includes('already exists')) {
+      if (stderr.includes(ALREADY_EXISTS_PATTERN)) {
         throw new MCPAlreadyExistsError('serena');
       }
 
@@ -180,7 +191,7 @@ export class MCPInstaller {
       const stderr = error.stderr?.toString() || error.message || '';
 
       // Check if it's "already exists" error
-      if (stderr.includes('already exists')) {
+      if (stderr.includes(ALREADY_EXISTS_PATTERN)) {
         throw new MCPAlreadyExistsError('context7');
       }
 
@@ -199,7 +210,7 @@ export class MCPInstaller {
       const stderr = error.stderr?.toString() || error.message || '';
 
       // Check if it's "already exists" error
-      if (stderr.includes('already exists')) {
+      if (stderr.includes(ALREADY_EXISTS_PATTERN)) {
         throw new MCPAlreadyExistsError('chrome-devtools');
       }
 
@@ -218,7 +229,7 @@ export class MCPInstaller {
       const stderr = error.stderr?.toString() || error.message || '';
 
       // Check if it's "already exists" error
-      if (stderr.includes('already exists')) {
+      if (stderr.includes(ALREADY_EXISTS_PATTERN)) {
         throw new MCPAlreadyExistsError('playwright');
       }
 

--- a/src/cli/utils/mcp-installer.ts
+++ b/src/cli/utils/mcp-installer.ts
@@ -73,8 +73,14 @@ export class MCPInstaller {
         report.successful.push('serena');
         console.log(chalk.green('✅ Serena (Code Intelligence) installed\n'));
       } catch (error) {
-        report.failed.push('serena');
-        console.log(chalk.red(`❌ Serena installation failed: ${(error as Error).message}\n`));
+        const message = (error as Error).message;
+        if (message.startsWith('SKIP:')) {
+          report.skipped.push('serena (already installed)');
+          console.log(chalk.yellow('⏭️  Serena - Already installed (skipped)\n'));
+        } else {
+          report.failed.push('serena');
+          console.log(chalk.red(`❌ Serena installation failed: ${message}\n`));
+        }
       }
     } else {
       report.skipped.push('serena');
@@ -87,8 +93,14 @@ export class MCPInstaller {
         report.successful.push('context7');
         console.log(chalk.green('✅ Context7 (Documentation) installed\n'));
       } catch (error) {
-        report.failed.push('context7');
-        console.log(chalk.red(`❌ Context7 installation failed: ${(error as Error).message}\n`));
+        const message = (error as Error).message;
+        if (message.startsWith('SKIP:')) {
+          report.skipped.push('context7 (already installed)');
+          console.log(chalk.yellow('⏭️  Context7 - Already installed (skipped)\n'));
+        } else {
+          report.failed.push('context7');
+          console.log(chalk.red(`❌ Context7 installation failed: ${message}\n`));
+        }
       }
     } else if (config.installContext7 && !config.context7ApiKey) {
       report.skipped.push('context7 (no API key provided)');
@@ -103,8 +115,14 @@ export class MCPInstaller {
         report.successful.push('chrome-devtools');
         console.log(chalk.green('✅ Chrome DevTools (Browser Automation) installed\n'));
       } catch (error) {
-        report.failed.push('chrome-devtools');
-        console.log(chalk.red(`❌ Chrome DevTools installation failed: ${(error as Error).message}\n`));
+        const message = (error as Error).message;
+        if (message.startsWith('SKIP:')) {
+          report.skipped.push('chrome-devtools (already installed)');
+          console.log(chalk.yellow('⏭️  Chrome DevTools - Already installed (skipped)\n'));
+        } else {
+          report.failed.push('chrome-devtools');
+          console.log(chalk.red(`❌ Chrome DevTools installation failed: ${message}\n`));
+        }
       }
     } else {
       report.skipped.push('chrome-devtools');
@@ -117,8 +135,14 @@ export class MCPInstaller {
         report.successful.push('playwright');
         console.log(chalk.green('✅ Playwright (E2E Testing) installed\n'));
       } catch (error) {
-        report.failed.push('playwright');
-        console.log(chalk.red(`❌ Playwright installation failed: ${(error as Error).message}\n`));
+        const message = (error as Error).message;
+        if (message.startsWith('SKIP:')) {
+          report.skipped.push('playwright (already installed)');
+          console.log(chalk.yellow('⏭️  Playwright - Already installed (skipped)\n'));
+        } else {
+          report.failed.push('playwright');
+          console.log(chalk.red(`❌ Playwright installation failed: ${message}\n`));
+        }
       }
     } else {
       report.skipped.push('playwright');
@@ -137,6 +161,13 @@ export class MCPInstaller {
     try {
       execSync(command, { stdio: 'pipe' });
     } catch (error: any) {
+      const stderr = error.stderr?.toString() || error.message || '';
+
+      // Check if it's "already exists" error
+      if (stderr.includes('already exists')) {
+        throw new Error('SKIP: already installed');
+      }
+
       throw new MCPInstallationError('Serena', error);
     }
   }
@@ -149,6 +180,13 @@ export class MCPInstaller {
     try {
       execSync(command, { stdio: 'pipe' });
     } catch (error: any) {
+      const stderr = error.stderr?.toString() || error.message || '';
+
+      // Check if it's "already exists" error
+      if (stderr.includes('already exists')) {
+        throw new Error('SKIP: already installed');
+      }
+
       throw new MCPInstallationError('Context7', error);
     }
   }
@@ -161,6 +199,13 @@ export class MCPInstaller {
     try {
       execSync(command, { stdio: 'pipe' });
     } catch (error: any) {
+      const stderr = error.stderr?.toString() || error.message || '';
+
+      // Check if it's "already exists" error
+      if (stderr.includes('already exists')) {
+        throw new Error('SKIP: already installed');
+      }
+
       throw new MCPInstallationError('Chrome DevTools', error);
     }
   }
@@ -173,6 +218,13 @@ export class MCPInstaller {
     try {
       execSync(command, { stdio: 'pipe' });
     } catch (error: any) {
+      const stderr = error.stderr?.toString() || error.message || '';
+
+      // Check if it's "already exists" error
+      if (stderr.includes('already exists')) {
+        throw new Error('SKIP: already installed');
+      }
+
       throw new MCPInstallationError('Playwright', error);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #108 - MCP servers that already exist in local config are now correctly treated as **skipped** instead of **failed** during `regent init` installation.

## Changes

- ✅ Updated all 4 MCP install methods (`installSerena`, `installContext7`, `installChromeDevTools`, `installPlaywright`) to detect "already exists" errors
- ✅ Modified `installAll()` method to handle skipped servers correctly
- ✅ Changed console output to show yellow ⏭️ for already installed servers instead of red ❌
- ✅ Updated installation report to display skipped servers with neutral language

## Before

```
❌ Serena installation failed: MCP server serena already exists in local config
```

**Installation Report:**
```
❌ Failed to install (1):
   • serena
```

## After

```
⏭️  Serena - Already installed (skipped)
```

**Installation Report:**
```
⏭️  Skipped (1):
   • serena (already installed)
```

## Impact

- ✅ Eliminates user confusion about failed installations
- ✅ Provides accurate reporting with appropriate indicators
- ✅ Improves UX with neutral messaging for existing servers

## Test Plan

- [x] Code changes implemented across all 4 MCP server installation methods
- [x] Error detection logic handles "already exists" pattern
- [x] Installation report correctly categorizes skipped servers
- [ ] Manual testing with pre-existing MCP servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)