### PR TITLE
docs: fix package name from @the-regent/cli to the-regent-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > **Multi-Target Clean Architecture Platform with AI-Powered Generation and Guaranteed Quality**
 
-[![NPM Version](https://img.shields.io/npm/v/@the-regent/cli)](https://www.npmjs.com/package/@the-regent/cli)
-[![NPM Downloads](https://img.shields.io/npm/dm/@the-regent/cli)](https://www.npmjs.com/package/@the-regent/cli)
+[![NPM Version](https://img.shields.io/npm/v/the-regent-cli)](https://www.npmjs.com/package/the-regent-cli)
+[![NPM Downloads](https://img.shields.io/npm/dm/the-regent-cli)](https://www.npmjs.com/package/the-regent-cli)
 [![RLHF Score](https://img.shields.io/badge/RLHF%20Score-Validation%20System-brightgreen)](https://github.com/thiagobutignon/the-regent)
 [![Clean Architecture](https://img.shields.io/badge/Clean%20Architecture-✓-blue)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
 [![Multi-Target](https://img.shields.io/badge/Multi--Target-25%2B%20Template%20Combinations-purple)](./templates)
 [![AI-NOTEs](https://img.shields.io/badge/AI--NOTEs-Guided%20Generation-orange)](./templates)
 [![Claude AI](https://img.shields.io/badge/Claude%20AI-6%20Agents-cyan)](./.claude/agents)
-[![CLI Tool](https://img.shields.io/badge/CLI-regent-blue)](https://www.npmjs.com/package/@the-regent/cli)
+[![CLI Tool](https://img.shields.io/badge/CLI-regent-blue)](https://www.npmjs.com/package/the-regent-cli)
 
 ## 📋 Overview
 
@@ -87,7 +87,7 @@ The true "secret sauce" isn't just generating code - it's generating **contextua
 
 ```bash
 # Install globally from NPM
-npm install -g @the-regent/cli
+npm install -g the-regent-cli
 
 # Verify installation
 regent --version
@@ -550,14 +550,14 @@ MCP Tools:
 
 ```bash
 # Install globally from NPM
-npm install -g @the-regent/cli
+npm install -g the-regent-cli
 
 # Verify installation
 regent --version  # Should show 2.1.9
 regent check      # Validate system requirements
 ```
 
-**🌍 Official NPM Package**: https://www.npmjs.com/package/@the-regent/cli
+**🌍 Official NPM Package**: https://www.npmjs.com/package/the-regent-cli
 
 ### 📦 **Prerequisites**
 


### PR DESCRIPTION
## Summary
Fixes incorrect package name references in README.md.

## Changes
- ✅ Updated NPM badge URLs from `@the-regent/cli` to `the-regent-cli`
- ✅ Fixed installation commands to use correct package name
- ✅ Corrected official NPM package link
- ✅ Command `regent` remains unchanged (as expected)

## Corrected References
1. NPM Version badge
2. NPM Downloads badge  
3. CLI Tool badge
4. Installation command (line 90)
5. Installation command (line 553)
6. Official package link (line 560)

## Before
```bash
npm install -g @the-regent/cli
```

## After
```bash
npm install -g the-regent-cli
```

## Context
Referenced issues #152 and #145 for awareness:
- **#152**: Process for maintaining prompt consistency (for future implementation)
- **#145**: Document edge cases for modular YAML (for future documentation)

These issues are tracked for future work but not addressed in this PR.

## Test Plan
- [x] Verified all 6 occurrences of `@the-regent/cli` replaced
- [x] Confirmed command `regent` is correctly maintained throughout
- [x] Badge URLs point to correct package
- [ ] Test installation from NPM (requires package publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)